### PR TITLE
Use bitvector versions of rotate functions

### DIFF
--- a/translator/config_function_maps.py
+++ b/translator/config_function_maps.py
@@ -208,8 +208,8 @@ def handwritten():
 		'ms'					: ms_fn,
 		'fault'					: fault_fn,
 		'b-xor'					: b_xor_fn,
-		'fast-rotate-left'		: rotate_left_fn,
-		'fast-rotate-right'		: rotate_right_fn,
+#		'fast-rotate-left'		: rotate_left_fn,
+#		'fast-rotate-right'		: rotate_right_fn,
 		'merge-2-u64s'			: merge_2_u64s_fn,
 		'merge-2-u32s'			: merge_2_u32s_fn,
 		'merge-4-u32s'			: merge_4_u32s_fn,
@@ -226,10 +226,12 @@ def handwritten():
 		return {'func': func, 'numOfArgs': numOfArgs, 'coerceActuals': coerceActuals}
 
 	dependentHandwrittenDefs = {
-		'loghead'	: dependent_fn(loghead_fn, 2, coerceActuals=True),
-		'logbitp'	: dependent_fn(logbitp_fn, 2, coerceActuals=True),
-		'logbit'	: dependent_fn(logbit_fn, 2, coerceActuals=True),
-		'lognot'	: dependent_fn(lognot_fn, 1, coerceActuals=False),
+		'loghead'		: dependent_fn(loghead_fn, 2, coerceActuals=True),
+		'logbitp'		: dependent_fn(logbitp_fn, 2, coerceActuals=True),
+		'logbit'		: dependent_fn(logbit_fn, 2, coerceActuals=True),
+		'lognot'		: dependent_fn(lognot_fn, 1, coerceActuals=False),
+                'fast-rotate-left'	: dependent_fn(rotate_left_fn, 3, coerceActuals=True),
+                'fast-rotate-right'	: dependent_fn(rotate_right_fn, 3, coerceActuals=True),
 	}
 	for (name, fn) in dependentHandwrittenDefs.items():
 		name = name.upper()

--- a/translator/handwrittenSupport/prelude.sail
+++ b/translator/handwrittenSupport/prelude.sail
@@ -503,8 +503,15 @@ Based loosely on:
 	* http://www.cs.utexas.edu/users/moore/acl2/manuals/current/manual/?topic=ACL2____ROTATE-LEFT
 	* http://www.cs.utexas.edu/users/moore/acl2/manuals/current/manual/?topic=ACL2____ROTATE-RIGHT
 */
-val rotate_left : (int, int, int) -> int
-function rotate_left (x, width, places) = {
+val rotate_left_bits : forall 'n. (bits('n), int, int) -> bits('n)
+function rotate_left_bits (x, width, places) = {
+  let high = sail_shiftleft(x, places);
+  let low = sail_shiftright(x, width-places);
+  high | low
+}
+
+val rotate_left_int : (int, int, int) -> int
+function rotate_left_int (x, width, places) = {
 	assert(0 <= places);
 	placesMod = mod(places, width);
 	low_num = width - placesMod;
@@ -512,15 +519,24 @@ function rotate_left (x, width, places) = {
 	xh = get_slice_int(placesMod, x, low_num);
 	unsigned(xl @ xh)
 }
+overload rotate_left = {rotate_left_bits, rotate_left_int}
 
-val rotate_right : (int, int, int) -> int
-function rotate_right (x, width, places) = {
+val rotate_right_bits : forall 'n. (bits('n), int, int) -> bits('n)
+function rotate_right_bits (x, width, places) = {
+  let low = sail_shiftright(x, places);
+  let high = sail_shiftleft(x, width-places);
+  high | low
+}
+
+val rotate_right_int : (int, int, int) -> int
+function rotate_right_int (x, width, places) = {
 	assert(0 <= places);
 	placesMod = mod(places, width);
 	xl = get_slice_int(placesMod, x, 0);
 	xh = get_slice_int(width - placesMod, x, placesMod);
 	unsigned(xl @ xh)
 }
+overload rotate_right = {rotate_right_bits, rotate_right_int}
 
 /*-----------------------------------------------------------------*/
 /*

--- a/translator/handwritten_tokens.py
+++ b/translator/handwritten_tokens.py
@@ -315,15 +315,37 @@ b_xor_fn = SailHandwrittenFn(
 	Sail_t_fn([Sail_t_int(), Sail_t_int()], Sail_t_int(), {'escape'})
 )
 
-rotate_left_fn = SailHandwrittenFn(
-	'rotate_left',
-	Sail_t_fn([Sail_t_int(), Sail_t_int(), Sail_t_int()], Sail_t_int(), {'escape'})
-)
+def rotate_left_fn(args, _):
+	if isinstance(args[0], SailApp) and args[0].getFn().getName() == 'unsigned':
+		arg = args[0].getActuals()[0]
+	else:
+		arg = args[0]
+	if isinstance(getType(arg), Sail_t_bits):
+		argType = getType(arg)
+	else:
+		argType = Sail_t_int()
+	return SailHandwrittenFn('rotate_left', Sail_t_fn([argType, Sail_t_int(), Sail_t_int()], argType))
 
-rotate_right_fn = SailHandwrittenFn(
-	'rotate_right',
-	Sail_t_fn([Sail_t_int(), Sail_t_int(), Sail_t_int()], Sail_t_int(), {'escape'})
-)
+def rotate_right_fn(args, _):
+	if isinstance(args[0], SailApp) and args[0].getFn().getName() == 'unsigned':
+		arg = args[0].getActuals()[0]
+	else:
+		arg = args[0]
+	if isinstance(getType(arg), Sail_t_bits):
+		argType = getType(arg)
+	else:
+		argType = Sail_t_int()
+	return SailHandwrittenFn('rotate_right', Sail_t_fn([argType, Sail_t_int(), Sail_t_int()], argType))
+
+#rotate_left_fn = SailHandwrittenFn(
+#	'rotate_left',
+#	Sail_t_fn([Sail_t_int(), Sail_t_int(), Sail_t_int()], Sail_t_int(), {'escape'})
+#)
+#
+#rotate_right_fn = SailHandwrittenFn(
+#	'rotate_right',
+#	Sail_t_fn([Sail_t_int(), Sail_t_int(), Sail_t_int()], Sail_t_int(), {'escape'})
+#)
 
 merge_2_u64s_fn = SailHandwrittenFn(
 	'merge_2_u64s',


### PR DESCRIPTION
Avoids symbolic lengths during symbolic execution for test generation